### PR TITLE
Different declarations

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+style=IntelliJ
+maxColumn=120

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: scala
 scala:
   - 2.12.0
+jdk:
+  - oraclejdk8
 script:
   - sbt sbt:scalafmt::test scalafmt::test test:scalafmt::test macros/scalafmt::test macros/test:scalafmt::test macros/test test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: scala
+scala:
+   - 2.12.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: scala
 scala:
-   - 2.12.0
+  - 2.12.0
+script:
+  - sbt sbt:scalafmt::test scalafmt::test test:scalafmt::test macros/scalafmt::test macros/test:scalafmt::test macros/test test

--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ val settings = Settler.settings[AppSettings](ConfigFactory.parseFile(myFile))
 It can be used out-of-the-box with [Typesafe's Config](https://github.com/typesafehub/config) or [Java Properties](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html). Additionally, you can implement your own `ConfigProvider` and use whatever source you prefer (custom file formats, databases, Redis, HTTP calls, etc).
 
 
+### Environment Variables Provider
+
+````scala
+trait Aws {
+  @Key(name = "AWS_SECRET_ACCESS_KEY")
+  def key: String
+  def awsSecretAccessKey: String
+}
+
+val s = Settler.settings[Aws](ConfigProvider.fromEnv())
+
+println(s.key == s.awsSecretAccessKey)
+````
+
+
 ### Alternative Name
 
 Case necessary, you can modify the key used to retrieve a setting by using the `@Key` annotation as so:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ trait AlternativeName {
 ```
 
 
+### Lazy vs Eagerly Loading
+ 
+Depending how your flag is declared, it might be lazy or eagerly loaded. As an example consider the following example:
+
+```scala
+trait Settings {
+  val eagerlyLoaded: String
+  def lazyLoaded: String
+}
+```
+
+
 ### Custom Types
 
 `settler` supports most of the common Scala types, like `Int`, `String`, `ConfigProvider`, `Duration`, `MemorySize`, plus these same types wrapped on `Seq`, `Set`, and/or `Option`.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ libraryDependencies += "com.unstablebuild" %% "settler" % "0.4.3"
 ## Release
 
 ```bash
-./sbt test
+./sbt test macros/test
 ./sbt publishSigned macros/publishSigned
 ./sbt sonatypeReleaseAll
 ```

--- a/README.md
+++ b/README.md
@@ -116,3 +116,11 @@ libraryDependencies += "com.unstablebuild" %% "settler" % "0.4.3"
 ./sbt publishSigned macros/publishSigned
 ./sbt sonatypeReleaseAll
 ```
+
+## Code Format
+
+This project uses [Scalafmt](http://scalameta.org/scalafmt/) for code formatting. This is done with the help of [neo-sbt-scalafmt](https://github.com/lucidsoftware/neo-sbt-scalafmt) SBT plugin:
+
+```bash
+./sbt sbt:scalafmt scalafmt test:scalafmt macros/scalafmt macros/test:scalafmt
+```

--- a/build.sbt
+++ b/build.sbt
@@ -52,3 +52,5 @@ lazy val macros = project.in(file("macros"))
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
     )
   )
+
+enablePlugins(com.lucidchart.sbt.scalafmt.ScalafmtPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,9 @@ lazy val commonSettings = Seq(
     "org.scalatest" %% "scalatest" % "3.0.0" % "test"
   ),
   resolvers ++= Seq(),
+  scalacOptions ++= Seq(
+    "-deprecation"
+  ),
   publishMavenStyle := true,
   publishTo := {
     val nexus = "https://oss.sonatype.org/"

--- a/build.sbt
+++ b/build.sbt
@@ -7,18 +7,14 @@ lazy val commonSettings = Seq(
   homepage := Some(url("https://github.com/lucastorri/settler")),
   organizationHomepage := Some(url("http://unstablebuild.com")),
   licenses := Seq("MIT License" -> url("https://opensource.org/licenses/MIT")),
-  libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "3.0.0" % "test"
-  ),
+  libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.0.0" % "test"),
   resolvers ++= Seq(),
-  scalacOptions ++= Seq(
-    "-deprecation"
-  ),
+  scalacOptions ++= Seq("-deprecation"),
   publishMavenStyle := true,
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
-    else Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+    else Some("releases" at nexus + "service/local/staging/deploy/maven2")
   },
   publishArtifact in Test := false,
   pomIncludeRepository := (_ => false),
@@ -36,14 +32,14 @@ lazy val commonSettings = Seq(
     </developers>
 )
 
-lazy val root = project.in(file("."))
+lazy val root = project
+  .in(file("."))
   .settings(commonSettings: _*)
   .dependsOn(macros)
-  .settings(
-    name := "settler"
-  )
+  .settings(name := "settler")
 
-lazy val macros = project.in(file("macros"))
+lazy val macros = project
+  .in(file("macros"))
   .settings(commonSettings: _*)
   .settings(
     name := "settler-macros",

--- a/macros/src/main/scala/com/unstablebuild/settler/Macros.scala
+++ b/macros/src/main/scala/com/unstablebuild/settler/Macros.scala
@@ -24,14 +24,14 @@ object Macros {
 
     val definitions = declarations.collect {
       case m: TermSymbol if m.isAbstract =>
-
-        def conf = m.annotations
-          .find(_.tree.tpe =:= typeOf[Key])
-          .map(_.tree)
-          .collectFirst {
-            case q"new $_(name = $name)" => name.toString
-          }
-          .getOrElse(m.asMethod.name.toString)
+        def conf =
+          m.annotations
+            .find(_.tree.tpe =:= typeOf[Key])
+            .map(_.tree)
+            .collectFirst {
+              case q"new $_(name = $name)" => name.toString
+            }
+            .getOrElse(m.asMethod.name.toString)
 
         def extract(base: Type): Tree = base match {
 
@@ -108,7 +108,8 @@ object Macros {
 
           case t @ TypeRef(_, _, args) if t <:< typeOf[Seq[Any]] && args.head.typeSymbol.isAbstract =>
             q"config.configSeq($conf).map(c => com.unstablebuild.settler.Macros.generate[${args.head}](c))"
-          case t @ TypeRef(_, _, args) if t.typeSymbol == typeOf[Set[Any]].typeSymbol && args.head.typeSymbol.isAbstract =>
+          case t @ TypeRef(_, _, args)
+              if t.typeSymbol == typeOf[Set[Any]].typeSymbol && args.head.typeSymbol.isAbstract =>
             q"config.configSeq($conf).map(c => com.unstablebuild.settler.Macros.generate[${args.head}](c)).toSet"
           case t if t.typeSymbol.isAbstract =>
             q"com.unstablebuild.settler.Macros.generate[$t](config.config($conf))"
@@ -130,8 +131,7 @@ object Macros {
         c.parse(s"${showDecl(m)} = ${showCode(body)}")
     }
 
-    c.Expr[T](
-      q"""{
+    c.Expr[T](q"""{
         new $tpe {
 
           private val config = $config

--- a/macros/src/main/scala/com/unstablebuild/settler/Macros.scala
+++ b/macros/src/main/scala/com/unstablebuild/settler/Macros.scala
@@ -19,8 +19,11 @@ object Macros {
     val error = typeOf[SettlerException]
     val parser = typeOf[ConfigParser[Any]].typeConstructor.typeSymbol
 
-    val definitions = tpe.decls.collect {
-      case m: MethodSymbol if m.isAbstract =>
+    // Drop `Object` and `Any`
+    val declarations = tpe.baseClasses.dropRight(2).flatMap(_.info.decls)
+
+    val definitions = declarations.collect {
+      case m: TermSymbol if m.isAbstract =>
 
         def conf = m.annotations
           .find(_.tree.tpe =:= typeOf[Key])

--- a/macros/src/main/scala/com/unstablebuild/settler/config/AlternativeNamesConfigProvider.scala
+++ b/macros/src/main/scala/com/unstablebuild/settler/config/AlternativeNamesConfigProvider.scala
@@ -50,10 +50,16 @@ object AlternativeNamesConfigProvider {
   def originalAndDash(provider: ConfigProvider): AlternativeNamesConfigProvider =
     AlternativeNamesConfigProvider(provider, Seq(alternatives.camelToDash))
 
+  def originalAndScreaming(provider: ConfigProvider): AlternativeNamesConfigProvider =
+    AlternativeNamesConfigProvider(provider, Seq(alternatives.camelToScreaming))
+
   object alternatives {
 
     def camelToDash(path: String): String =
       "(\\p{Upper}|\\d+)".r.replaceAllIn(path, m => s"-${m.matched.toLowerCase}").stripPrefix("-")
+
+    def camelToScreaming(path: String): String =
+      "(\\p{Upper}|\\d+)".r.replaceAllIn(path, m => s"_${m.matched}").stripPrefix("_").toUpperCase
 
   }
 

--- a/macros/src/main/scala/com/unstablebuild/settler/config/AlternativeNamesConfigProvider.scala
+++ b/macros/src/main/scala/com/unstablebuild/settler/config/AlternativeNamesConfigProvider.scala
@@ -5,7 +5,8 @@ import com.unstablebuild.settler.model.MemorySize
 
 import scala.concurrent.duration.Duration
 
-case class AlternativeNamesConfigProvider(provider: ConfigProvider, options: Seq[String => String]) extends ConfigProvider {
+case class AlternativeNamesConfigProvider(provider: ConfigProvider, options: Seq[String => String])
+    extends ConfigProvider {
 
   override def has(path: String): Boolean = provider.has(path)
 

--- a/macros/src/main/scala/com/unstablebuild/settler/config/ConfigProvider.scala
+++ b/macros/src/main/scala/com/unstablebuild/settler/config/ConfigProvider.scala
@@ -48,4 +48,7 @@ object ConfigProvider {
   implicit def fromConfig(config: Config): ConfigProvider =
     AlternativeNamesConfigProvider.originalAndDash(TypesafeConfigProvider(config))
 
+  def fromEnv(): ConfigProvider =
+    AlternativeNamesConfigProvider.originalAndScreaming(TypesafeConfigProvider(ConfigFactory.systemEnvironment()))
+
 }

--- a/macros/src/main/scala/com/unstablebuild/settler/config/TypesafeConfigProvider.scala
+++ b/macros/src/main/scala/com/unstablebuild/settler/config/TypesafeConfigProvider.scala
@@ -26,7 +26,8 @@ case class TypesafeConfigProvider(config: Config) extends ConfigProvider {
 
   override def number(path: String): Number = config.getNumber(path)
 
-  override def configSeq(path: String): Seq[ConfigProvider] = config.getConfigList(path).asScala.map(TypesafeConfigProvider)
+  override def configSeq(path: String): Seq[ConfigProvider] =
+    config.getConfigList(path).asScala.map(TypesafeConfigProvider)
 
   override def durationSeq(path: String): Seq[Duration] = config.getDurationList(path).asScala.map(toDuration)
 

--- a/macros/src/main/scala/com/unstablebuild/settler/config/TypesafeConfigProvider.scala
+++ b/macros/src/main/scala/com/unstablebuild/settler/config/TypesafeConfigProvider.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 import com.typesafe.config.{Config, ConfigMemorySize}
 import com.unstablebuild.settler.model.MemorySize
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.concurrent.duration.Duration
 import scala.language.implicitConversions
 
@@ -26,17 +26,17 @@ case class TypesafeConfigProvider(config: Config) extends ConfigProvider {
 
   override def number(path: String): Number = config.getNumber(path)
 
-  override def configSeq(path: String): Seq[ConfigProvider] = config.getConfigList(path).map(TypesafeConfigProvider)
+  override def configSeq(path: String): Seq[ConfigProvider] = config.getConfigList(path).asScala.map(TypesafeConfigProvider)
 
-  override def durationSeq(path: String): Seq[Duration] = config.getDurationList(path).map(toDuration)
+  override def durationSeq(path: String): Seq[Duration] = config.getDurationList(path).asScala.map(toDuration)
 
-  override def stringSeq(path: String): Seq[String] = config.getStringList(path)
+  override def stringSeq(path: String): Seq[String] = config.getStringList(path).asScala
 
-  override def memSizeSeq(path: String): Seq[MemorySize] = config.getMemorySizeList(path).map(toMemSize)
+  override def memSizeSeq(path: String): Seq[MemorySize] = config.getMemorySizeList(path).asScala.map(toMemSize)
 
-  override def boolSeq(path: String): Seq[Boolean] = config.getBooleanList(path).map(_.booleanValue())
+  override def boolSeq(path: String): Seq[Boolean] = config.getBooleanList(path).asScala.map(_.booleanValue())
 
-  override def numberSeq(path: String): Seq[Number] = config.getNumberList(path)
+  override def numberSeq(path: String): Seq[Number] = config.getNumberList(path).asScala
 
   override def obj(path: String): AnyRef = config.getAnyRef(path)
 

--- a/macros/src/main/scala/com/unstablebuild/settler/error/SettlerException.scala
+++ b/macros/src/main/scala/com/unstablebuild/settler/error/SettlerException.scala
@@ -2,4 +2,6 @@ package com.unstablebuild.settler.error
 
 import scala.util.control.NoStackTrace
 
-case class SettlerException(message: String = null, cause: Throwable = null) extends Exception(message, cause) with NoStackTrace
+case class SettlerException(message: String = null, cause: Throwable = null)
+    extends Exception(message, cause)
+    with NoStackTrace

--- a/macros/src/main/scala/com/unstablebuild/settler/model/MemorySize.scala
+++ b/macros/src/main/scala/com/unstablebuild/settler/model/MemorySize.scala
@@ -1,10 +1,5 @@
 package com.unstablebuild.settler.model
 
-import java.time.{Duration => JavaDuration}
-
-import scala.language.experimental.macros
-
-
 case class MemorySize(toBytes: Long) extends Ordered[MemorySize] {
 
   override def compare(that: MemorySize): Int = toBytes.compareTo(that.toBytes)

--- a/macros/src/test/scala/com/unstablebuild/settler/config/AlternativeNamesConfigProviderTest.scala
+++ b/macros/src/test/scala/com/unstablebuild/settler/config/AlternativeNamesConfigProviderTest.scala
@@ -7,19 +7,20 @@ class AlternativeNamesConfigProviderTest extends FlatSpec with MustMatchers {
 
   it must "convert camel case names to dash separated" in {
 
-    val provider = AlternativeNamesConfigProvider.originalAndDash(
-      ConfigFactory.parseString("""with-a-number-42 = true"""))
+    val provider =
+      AlternativeNamesConfigProvider.originalAndDash(ConfigFactory.parseString("""with-a-number-42 = true"""))
 
-    provider.bool("withANumber42") must be (true)
-    provider.bool("WithANumber42") must be (true)
+    provider.bool("withANumber42") must be(true)
+    provider.bool("WithANumber42") must be(true)
   }
 
   it must "copy the provider for nested values" in {
 
     val provider = AlternativeNamesConfigProvider.originalAndDash(
-      ConfigFactory.parseString("""first-level = { second-level = 51 }"""))
+      ConfigFactory.parseString("""first-level = { second-level = 51 }""")
+    )
 
-    provider.config("firstLevel").number("secondLevel").intValue() must be (51)
+    provider.config("firstLevel").number("secondLevel").intValue() must be(51)
   }
 
 }

--- a/macros/src/test/scala/com/unstablebuild/settler/config/AlternativeNamesConfigProviderTest.scala
+++ b/macros/src/test/scala/com/unstablebuild/settler/config/AlternativeNamesConfigProviderTest.scala
@@ -14,6 +14,14 @@ class AlternativeNamesConfigProviderTest extends FlatSpec with MustMatchers {
     provider.bool("WithANumber42") must be(true)
   }
 
+  it must "convert camel case names to screaming case" in {
+    val provider =
+      AlternativeNamesConfigProvider.originalAndScreaming(ConfigFactory.parseString("""HELLO_WORLD = true"""))
+
+    provider.bool("helloWorld") must be(true)
+    provider.bool("HelloWorld") must be(true)
+  }
+
   it must "copy the provider for nested values" in {
 
     val provider = AlternativeNamesConfigProvider.originalAndDash(

--- a/project/scalafmt.sbt
+++ b/project/scalafmt.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt-coursier" % "1.6")
+

--- a/src/test/scala/com/unstablebuild/settler/SettlerTest.scala
+++ b/src/test/scala/com/unstablebuild/settler/SettlerTest.scala
@@ -127,6 +127,15 @@ class SettlerTest extends FlatSpec with MustMatchers {
     }
   }
 
+  it must "implement settings from parents" in {
+
+    val settings = Settler.settings[Extended](ConfigFactory.parseString("""
+        |a-string = "hey, ho!"
+      """.stripMargin))
+
+    settings.aString must equal ("hey, ho!")
+  }
+
 }
 
 trait All {
@@ -199,3 +208,5 @@ trait MissingVal {
   val missingSetting: String
 
 }
+
+trait Extended extends Val

--- a/src/test/scala/com/unstablebuild/settler/SettlerTest.scala
+++ b/src/test/scala/com/unstablebuild/settler/SettlerTest.scala
@@ -12,13 +12,12 @@ import scala.concurrent.duration._
 
 class SettlerTest extends FlatSpec with MustMatchers {
 
-   implicit val classParser = new ConfigParser[Class[_]] {
-      override def apply(value: AnyRef): Class[_] = Class.forName(value.toString)
-    }
+  implicit val classParser = new ConfigParser[Class[_]] {
+    override def apply(value: AnyRef): Class[_] = Class.forName(value.toString)
+  }
 
   val settings =
-    Settler.settings[All](
-      ConfigFactory.parseString("""
+    Settler.settings[All](ConfigFactory.parseString("""
         |int = 3
         |str = "hello"
         |optIn = "I'm here"
@@ -49,41 +48,41 @@ class SettlerTest extends FlatSpec with MustMatchers {
         """.stripMargin))
 
   it must "handle integers" in {
-    settings.int must be (3)
+    settings.int must be(3)
   }
 
   it must "handle strings" in {
-    settings.str must equal ("hello")
+    settings.str must equal("hello")
   }
 
   it must "handle optional values" in {
-    settings.optIn must equal (Some("I'm here"))
-    settings.optOut must be (None)
+    settings.optIn must equal(Some("I'm here"))
+    settings.optOut must be(None)
   }
 
   it must "handle other settings" in {
-    settings.b.anotherInt must be (51)
+    settings.b.anotherInt must be(51)
   }
 
   it must "handle lists" in {
-    settings.list must equal (Seq("a", "b"))
+    settings.list must equal(Seq("a", "b"))
   }
 
   it must "handle sets" in {
-    settings.set must equal (Set(1, 2, 3))
+    settings.set must equal(Set(1, 2, 3))
   }
 
   it must "allow implemented method" in {
-    settings.optInOrElse must equal ("I'm here")
-    settings.optOutOrElse must equal ("default")
+    settings.optInOrElse must equal("I'm here")
+    settings.optOutOrElse must equal("default")
   }
 
   it must "handle settings lists" in {
-    settings.pairSeq.map(p => p.key -> p.value) must equal (Seq("hey" -> 21))
+    settings.pairSeq.map(p => p.key -> p.value) must equal(Seq("hey" -> 21))
   }
 
   it must "handle settings sets" in {
-    settings.pairSet.map(p => p.key -> p.value) must equal (Set("hi" -> 31))
+    settings.pairSet.map(p => p.key -> p.value) must equal(Set("hi" -> 31))
   }
 
   it must "throw an exception if type doesn't match the interface" in {
@@ -97,15 +96,15 @@ class SettlerTest extends FlatSpec with MustMatchers {
   }
 
   it must "allow setting the base name" in {
-    settings.renamed must equal (1.23)
+    settings.renamed must equal(1.23)
   }
 
   it must "try dash separated names" in {
-    settings.camelCaseToDashSeparated.camelCaseInt must equal (67)
+    settings.camelCaseToDashSeparated.camelCaseInt must equal(67)
   }
 
   it must "allow custom parsers" in {
-    settings.b.customType must equal (classOf[File])
+    settings.b.customType must equal(classOf[File])
   }
 
   it must "lazy load def settings" in {
@@ -115,12 +114,11 @@ class SettlerTest extends FlatSpec with MustMatchers {
   }
 
   it must "eagerly load val settings" in {
-    val valueSetting = Settler.settings[Val](ConfigFactory.parseString(
-      """
+    val valueSetting = Settler.settings[Val](ConfigFactory.parseString("""
         |a-string = "hey, ho!"
       """.stripMargin))
 
-    valueSetting.aString must equal ("hey, ho!")
+    valueSetting.aString must equal("hey, ho!")
 
     a[SettlerException] must be thrownBy {
       Settler.settings[MissingVal](ConfigFactory.empty)
@@ -133,7 +131,7 @@ class SettlerTest extends FlatSpec with MustMatchers {
         |a-string = "hey, ho!"
       """.stripMargin))
 
-    settings.aString must equal ("hey, ho!")
+    settings.aString must equal("hey, ho!")
   }
 
 }


### PR DESCRIPTION
Changes:

- Allow extended traits to implement setting methods from their parents:

```scala
trait Parent {
  def myNumber: Int
}

trait Child extends Parent

Settler.settings[Child](/*...*/)
// Will correctly implement the `myNumber` method.
```

- Allow lazy/eager loading of settings based on declaration:

```scala
trait Settings {
  val eagerlyLoaded: String
  def lazyLoaded: String
}
```

- Format code using [scalafmt](http://scalafmt.org/)

- Add a config provider that uses environment variables:

```scala
trait Aws {
  @Key(name = "AWS_SECRET_ACCESS_KEY")
  def key: String
  def awsSecretAccessKey: String
}

val s = Settler.settings[Aws](ConfigProvider.fromEnv())

println(s.key == s.awsSecretAccessKey)
```